### PR TITLE
Remove images-aws module dependency

### DIFF
--- a/_interface.tf
+++ b/_interface.tf
@@ -11,6 +11,10 @@ variable "environment_name" {
   description = "Environment Name (tagged to all instances)"
 }
 
+variable "nomad_version" {
+  description = "Nomad version to use eg 0.6.0 or 0.6.0+ent"
+}
+
 variable "os" {
   # case sensitive for AMI lookup
   description = "Operating System to use ie RHEL or Ubuntu"
@@ -35,7 +39,7 @@ variable "vpc_id" {
 
 variable "vpc_cidr_block" {
   description = "Pre-existing VPC cidr block to use"
-  default = ""
+  default     = ""
 }
 
 # Optional variables
@@ -47,6 +51,11 @@ variable "cluster_size" {
 variable "consul_as_server" {
   default     = "true"
   description = "Run the consul agent in server mode: true/false"
+}
+
+variable "environment" {
+  default     = "production"
+  description = "Environment eg development, stage or production"
 }
 
 variable "instance_type" {
@@ -67,11 +76,6 @@ variable "nomad_as_server" {
 variable "nomad_use_consul" {
   default     = "true"
   description = "Use nomad with consul: true/false"
-}
-
-variable "nomad_version" {
-  default     = "0.6.0"
-  description = "Nomad Agent version to use ie 0.5.6"
 }
 
 variable "region" {

--- a/nomad.tf
+++ b/nomad.tf
@@ -2,11 +2,48 @@ terraform {
   required_version = ">= 0.9.3"
 }
 
-module "images-aws" {
-  source        = "git@github.com:hashicorp-modules/images-aws.git?ref=2017-08-10"
-  nomad_version = "${var.nomad_version}"
-  os            = "${var.os}"
-  os_version    = "${var.os_version}"
+provider "aws" {
+  region = "${var.region}"
+}
+
+data "aws_ami" "nomad" {
+  most_recent = true
+  owners      = ["362381645759"] # hc-se-demos Hashicorp Demos New Account
+
+  filter {
+    name   = "tag:System"
+    values = ["Nomad"]
+  }
+
+  filter {
+    name   = "tag:Environment"
+    values = ["${var.environment}"]
+  }
+
+  filter {
+    name   = "tag:Product-Version"
+    values = ["${var.nomad_version}"]
+  }
+
+  filter {
+    name   = "tag:OS"
+    values = ["${var.os}"]
+  }
+
+  filter {
+    name   = "tag:OS-Version"
+    values = ["${var.os_version}"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 }
 
 resource "aws_iam_role" "nomad_server" {
@@ -39,19 +76,18 @@ data "template_file" "init" {
 }
 
 resource "aws_launch_configuration" "nomad_server" {
-  image_id      = "${module.images-aws.nomad_image}"
-  instance_type = "${var.instance_type}"
-  user_data     = "${data.template_file.init.rendered}"
-  key_name      = "${var.ssh_key_name}"
+  associate_public_ip_address = false
+  ebs_optimized               = false
+  iam_instance_profile        = "${aws_iam_instance_profile.nomad_server.id}"
+  image_id                    = "${data.aws_ami.nomad.id}"
+  instance_type               = "${var.instance_type}"
+  user_data                   = "${data.template_file.init.rendered}"
+  key_name                    = "${var.ssh_key_name}"
 
   security_groups = [
     "${aws_security_group.nomad_server.id}",
     "${var.consul_server_sg_id}",
   ]
-
-  associate_public_ip_address = false
-  ebs_optimized               = false
-  iam_instance_profile        = "${aws_iam_instance_profile.nomad_server.id}"
 
   lifecycle {
     create_before_destroy = true

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -26,18 +26,18 @@ resource "aws_security_group" "nomad_server" {
 
   # Nomad RPC
   ingress {
-    from_port   = 4647
-    to_port     = 4647
-    protocol    = "tcp"
-    self        = true
+    from_port = 4647
+    to_port   = 4647
+    protocol  = "tcp"
+    self      = true
   }
 
   # Nomad Serf
   ingress {
-    from_port   = 4648
-    to_port     = 4648
-    protocol    = "tcp"
-    self        = true
+    from_port = 4648
+    to_port   = 4648
+    protocol  = "tcp"
+    self      = true
   }
 
   # TCP All outbound traffic

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -19,5 +19,5 @@ subnet_ids = ["subnet-0ab1cd2e"]
 # Pre-existing VPC ID to use
 vpc_id = "vpc-123abc45"
 
-# Nomad version to use ie 0.5.6
-nomad_version = "0.5.6"
+# Nomad version to use eg 0.6.0 or 0.6.0+ent
+nomad_version = "0.6.0"


### PR DESCRIPTION
Speeds up data resource lookup and reduces chance of failure on lookup of unnecessary AMI IDs